### PR TITLE
Apply stored favicon color on initial page load

### DIFF
--- a/content.js
+++ b/content.js
@@ -36,6 +36,8 @@ observer.observe(document.head, {
   attributes: true
 });
 
+changeFavicon(null, currentColor);
+
 function scrapeEmailAddressFromPage() {
   var accountElement = document.querySelector(".gb_b.gb_Ra.gb_R");
   if (accountElement) {


### PR DESCRIPTION
## Summary
- The MutationObserver in `content.js` only recolors the favicon when Gmail mutates the `<link rel="icon">` after the content script runs. On a fresh reload, the favicon is often already present in the initial HTML, so no mutation fires and the stored color is never applied.
- Fix: call `changeFavicon(null, currentColor)` once after the observer is set up, so the stored color is applied immediately on load.

Note: Looks like this broke after it was initially implemented because of how Gmail HTML gets rendered.